### PR TITLE
Show systems without stellars in white, similar to the EV map

### DIFF
--- a/Plug-Ins/NovaTools/Galaxy Editor/SystemView.swift
+++ b/Plug-Ins/NovaTools/Galaxy Editor/SystemView.swift
@@ -57,7 +57,7 @@ class SystemView: NSView {
         navDefaults = try (0..<16).map { _ in
             Int(try reader.read() as Int16)
         }
-        hasStellars = navDefaults.contains(where: { $0 > -1 })
+        hasStellars = navDefaults.contains(where: { 128...2175 ~= $0 })
     }
 
     override func updateTrackingAreas() {

--- a/Plug-Ins/NovaTools/Galaxy Editor/SystemView.swift
+++ b/Plug-Ins/NovaTools/Galaxy Editor/SystemView.swift
@@ -6,6 +6,8 @@ class SystemView: NSView {
     let isEnabled: Bool
     private(set) var position = NSPoint.zero
     private(set) var links: [Int] = []
+    private(set) var navDefaults: [Int] = []
+    private(set) var hasStellars = false
     private var attributes: [NSAttributedString.Key: Any] {
         [.foregroundColor: NSColor.white, .font: NSFont.systemFont(ofSize: 11)]
     }
@@ -52,6 +54,10 @@ class SystemView: NSView {
         links = try (0..<16).map { _ in
             Int(try reader.read() as Int16)
         }
+        navDefaults = try (0..<16).map { _ in
+            Int(try reader.read() as Int16)
+        }
+        hasStellars = navDefaults.contains(where: { $0 > -1 })
     }
 
     override func updateTrackingAreas() {
@@ -157,7 +163,14 @@ class SystemView: NSView {
         } else {
             NSColor.black.setFill()
             if isEnabled {
-                NSColor.blue.setStroke()
+                // Systems without stellars show as white; otherwise they show as blue.
+                // This is not the same as EV logic, where only systems with inhabited, landable stellars owned
+                // by a govt with which the player is friendly show as blue.
+                if hasStellars {
+                    NSColor.blue.setStroke()
+                } else {
+                    NSColor.white.setStroke()
+                }
             } else {
                 NSColor.gray.setStroke()
             }


### PR DESCRIPTION
The EV map shows systems colored according to the following logic:

* For each inhabited, landable, non-destroyed stellar in the system, determine if:
    a) The stellar is dominated;
    b) The stellar is controlled by a government and the player has a blessed rank with that government;
    c) The player's record in that system is zero or higher, but the stellar requires a higher record;
    d) The player's record in that system is below zero and the stellar requires a higher record.
* If case (a) applies to any stellars, the system is rendered in green;
* If case (b) applies to any stellars, the system is rendered in blue;
* If case (c) applies to any stellars, the system is rendered in orange (forbidden);
* If case (d) applies to any stellars, the system is rendered in red (outlawed);
* If none of cases (a)-(d) apply to any stellar, but there is at least one inhabited, landable, non-destroyed stellar in the system, the system is rendered in blue;
* If none of the above cases apply, render the system in light grey.

This change implements a very simple subset of that logic, in which systems containing one or more stellars in their NavDefaults are drawn in blue, and systems with no stellars (i.e. "no stellar objects present") are drawn in white:

![image](https://github.com/user-attachments/assets/c6a83e3c-398e-4569-b8f6-294d5db82def)

This makes it a bit easier to see the structure of the galaxy, and during development can also help identify systems that have not yet been populated.

This change modifies `SystemView` to add a `hasStellars` flag for this purpose; it also loads and stores `NavDefaults`, which is not strictly necessary for the current functionality but it's low overhead and would help support possible future extensions such as showing EV map-like system info as an overlay.