### PR TITLE
BUGFIX: fixed unknown key exceptions for InfoWindowController.

### DIFF
--- a/Plugins/Sources/RFSupport/Resource.swift
+++ b/Plugins/Sources/RFSupport/Resource.swift
@@ -273,4 +273,10 @@ public class Resource: NSObject, NSSecureCoding, NSPasteboardWriting, NSPasteboa
     public required init?(pasteboardPropertyList propertyList: Any, ofType type: NSPasteboard.PasteboardType) {
         return nil
     }
+	
+	@objc public override func value(forUndefinedKey key: String) -> Any? {
+		let keys = ["hfsCreator", "hfsType"]
+		if keys.contains(key) { return nil }
+		return super.value(forUndefinedKey: key)
+	}
 }

--- a/ResForge/Classes/InfoWindowController.swift
+++ b/ResForge/Classes/InfoWindowController.swift
@@ -181,7 +181,8 @@ class InfoWindowController: NSWindowController, NSWindowDelegate, NSTextFieldDel
 
 class FourCharCodeTransformer: ValueTransformer {
     override func transformedValue(_ value: Any?) -> Any? {
-        return (value as! FourCharCode).fourCharString
+        guard let fourCC = value as? FourCharCode else { return nil }
+        return fourCC.fourCharString
     }
 
     override func reverseTransformedValue(_ value: Any?) -> Any? {

--- a/ResForge/Classes/ResourceDocument.swift
+++ b/ResForge/Classes/ResourceDocument.swift
@@ -688,4 +688,11 @@ class ResourceDocument: NSDocument, NSWindowDelegate, NSDraggingDestination, NST
             return []
         }
     }
+
+    @objc override func value(forUndefinedKey key: String) -> Any? {
+        let keys = ["isChanged", "isPreload", "isProtected", "isLocked", "isPurgeable", "isSysHeap",
+                    "typeCode", "id", "name"]
+        if keys.contains(key) { return nil }
+        return super.value(forUndefinedKey: key)
+    }
 }


### PR DESCRIPTION
The `InfoWindowController` holds onto a model object which could be either a `ResourceDocument` or a `Resource`. The textfields in the 2 different views are always bound to the properties (keys) of the Object Controller's object regardless of which type of object it is. For instance, if you open the Info window for the first time and have a `Resource` currently selected, you'd get an unknown key exception because `documentView`'s `type` field is bound to `hfsCreator`, which `Resource` does not understand. It'd lead to a logging like the following:

```
FAULT: NSUnknownKeyException: [<RFSupport.Resource 0x9bf64da40> valueForUndefinedKey:]: this class is not key value coding-compliant for the key hfsCreator.; {
    NSTargetObjectUserInfoKey = "<RFSupport.Resource: 0x9bf64da40>";
    NSUnknownUserInfoKey = hfsCreator;
}

```
So I just overrode `value(forUndefinedKey:)` to return nil for properties the classes don't handle. That necessitated revising `FourCharCodeTransformer` to deal with nil values.