### PR TITLE
Fix crash on DITL with no items

### DIFF
--- a/Plugins/Sources/DialogEditor/DialogEditor.swift
+++ b/Plugins/Sources/DialogEditor/DialogEditor.swift
@@ -80,9 +80,12 @@ public class DialogEditor: AbstractEditor, ResourceEditor {
     private func itemsFromData(_ data: Data) throws {
         let reader = BinaryDataReader(data)
         let itemCountMinusOne: Int16 = try reader.read()
-        for _ in 0...itemCountMinusOne {
-            let item = try DITLItemView(reader, manager: manager)
-            items.append(item)
+        // Guard against DITLs with 0 items
+        if itemCountMinusOne >= 0 {
+            for _ in 0...itemCountMinusOne {
+                let item = try DITLItemView(reader, manager: manager)
+                items.append(item)
+            }
         }
     }
 


### PR DESCRIPTION
For a DITL with no items, the entire DITL is the 2-byte value '0xffff' and itemCountMinusOne is -1. This crashes the loop in itemsFromData(), so guard against it.